### PR TITLE
refactor(*): use `for`-`of` instead of `forEach` for faster iteration

### DIFF
--- a/src/textlint-rule-allowed-uris.js
+++ b/src/textlint-rule-allowed-uris.js
@@ -146,21 +146,21 @@ export default function textlintRuleAllowedUris(context, rawOptions) {
     Html(node) {
       const html = node.value;
 
-      getElementsByTagName(html, 'a').forEach(({ attrs }) => {
-        attrs.forEach(({ name, value }) => {
+      for (const { attrs } of getElementsByTagName(html, 'a')) {
+        for (const { name, value } of attrs) {
           if (name === 'href') {
             links.add({ node, uri: value });
           }
-        });
-      });
+        }
+      }
 
-      getElementsByTagName(html, 'img').forEach(({ attrs }) => {
-        attrs.forEach(({ name, value }) => {
+      for (const { attrs } of getElementsByTagName(html, 'img')) {
+        for (const { name, value } of attrs) {
           if (name === 'src') {
             images.add({ node, uri: value });
           }
-        });
-      });
+        }
+      }
     },
 
     /** @param {TxtLinkReferenceNode} node */


### PR DESCRIPTION
This pull request refactors the way HTML anchor and image tags are processed in the `textlintRuleAllowedUris` function for improved readability and maintainability. The main logic is unchanged, but the nested `.forEach` calls have been replaced with more modern and readable `for...of` loops.

Refactoring for clarity and maintainability:

* Replaced nested `.forEach` calls with `for...of` loops when iterating over the attributes of `<a>` and `<img>` elements in the `Html` node handler of `textlintRuleAllowedUris`. This makes the code easier to follow and less error-prone.