### PR TITLE
chore(release): bump package versions from `v2.0.2` to `v2.0.3` (`patch`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "textlint-rule-allowed-uris",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "workspaces": [
         "."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "workspaces": [


### PR DESCRIPTION
## Release Information: `v2.0.3`

New release of `lumirlumir/npm-textlint-rule-allowed-uris` has arrived! :tada:

This PR bumps the package versions from `v2.0.2` to `v2.0.3` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/actions/runs/25920809426) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-textlint-rule-allowed-uris` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 1ae61d5       |
| Old Version | `v2.0.2`  |
| New Version | `v2.0.3`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :toolbox: Chores
* chore(*): replace `textlint` with `eslint-plugin-mark` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/378
* chore(sync-server): update `dependabot.yml` and dependencies by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/385
* chore(sync-server): update dependencies by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/390
* chore(sync-server): update dev-dependencies and Prettier config by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/393
* chore(sync-server): migrate to `eslint-markdown` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/394
* chore(*): add `funding` field to `package.json` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/411
* chore(sync-server): update configurations and dev-dependencies by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/412
* chore(sync-server): update dependencies and configs by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/414
* chore(sync-server): update `marocchino/sticky-pull-request-comment` to v3 by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/425
* chore(sync-server): bump GitHub Actions and configurations by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/430
* chore(*): update `tsconfig.json` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/433
* chore(sync-server): update ignore files by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/434
* chore(sync-server): update CI script and rename config file extensions by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/441
* chore(*): rename GitHub Actions workflow by @Copilot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/444
* chore(sync-server): rename username to `lumir` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/452
### :arrows_counterclockwise: Continuous Integrations
* ci(sync-server): update runner image and dev-dependencies by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/404
* ci(sync-server): reestablish cache strategy for a faster CI by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/438
* ci(*): (perf) remove unnecessary `npx` prefixes by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/440
* ci(sync-server): merge lint and test workflow configs into ci by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/442
### :recycle: Code Refactoring
* refactor(*): use `for`-`of` instead of `forEach` for faster iteration by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/453
### :arrow_up: Dependency Updates
* chore(deps-dev): bump markdownlint-cli from 0.45.0 to 0.46.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/380
* chore(deps): bump glob from 10.4.5 to 10.5.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/381
* chore(deps): bump actions/checkout from 5 to 6 by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/383
* chore(deps): bump actions/checkout from 5 to 6 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/382
* chore(deps-dev): bump prettier from 3.6.2 to 3.7.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/384
* chore(deps-dev): bump @types/node from 24.10.3 to 24.10.4 in the types group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/392
* chore(deps-dev): bump eslint-markdown from 0.1.0-canary.12 to 0.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/395
* chore(deps-dev): bump @types/node from 24.10.4 to 24.10.7 in the types group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/396
* chore(deps-dev): bump eslint-markdown from 0.1.0 to 0.2.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/397
* chore(deps-dev): bump @types/node from 24.10.7 to 24.10.8 in the types group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/398
* chore(deps-dev): bump prettier from 3.7.4 to 3.8.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/399
* chore(deps-dev): bump @types/node from 24.10.8 to 24.10.9 in the types group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/400
* chore(deps-dev): bump eslint-markdown from 0.2.0 to 0.3.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/401
* chore(deps-dev): bump lodash from 4.17.21 to 4.17.23 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/403
* chore(deps-dev): bump @types/node from 24.10.9 to 24.10.10 in the types group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/405
* chore(deps-dev): bump @types/node from 24.10.10 to 24.10.11 in the types group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/406
* chore(deps-dev): bump eslint-markdown from 0.3.0 to 0.4.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/408
* chore(deps-dev): update dev-dependencies by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/407
* chore(deps-dev): bump eslint-markdown from 0.4.0 to 0.5.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/410
* chore(deps-dev): bump lint-staged from 16.2.7 to 16.3.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/418
* chore(deps-dev): bump minimatch from 3.1.2 to 3.1.5 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/417
* chore(deps-dev): bump eslint from 9.39.3 to 9.39.4 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/420
* chore(deps-dev): bump lint-staged from 16.3.2 to 16.3.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/421
* chore(deps-dev): bump @types/node from 24.11.0 to 24.12.0 in the types group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/419
* chore(deps-dev): bump eslint-markdown from 0.5.0 to 0.6.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/423
* chore(deps-dev): bump flatted from 3.3.3 to 3.4.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/426
* chore(deps-dev): bump lint-staged from 16.3.3 to 16.4.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/424
* chore(deps): bump picomatch by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/428
* chore(deps-dev): bump the dev-dependencies group across 1 directory with 4 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/432
* chore(deps-dev): bump lodash from 4.17.23 to 4.18.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/431
* chore(deps-dev): bump eslint-markdown from 0.6.0 to 0.6.1 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/435
* chore(deps-dev): bump prettier from 3.8.1 to 3.8.2 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/437
* chore(deps-dev): bump typescript from 6.0.2 to 6.0.3 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/439
* chore(deps-dev): bump eslint-markdown from 0.6.1 to 0.7.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/445
* chore(deps-dev): bump eslint-markdown from 0.7.0 to 0.9.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/448
* chore(deps-dev): bump fast-uri from 3.0.6 to 3.1.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/450
* chore(deps-dev): bump @types/node from 24.12.2 to 24.12.4 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/454


**Full Changelog**: https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/compare/v2.0.2...v2.0.3